### PR TITLE
[FIX] Cant set SF in arithmetic operations with quadword

### DIFF
--- a/src/main/java/it/uniroma2/pellegrini/z64sim/controller/SimulatorController.java
+++ b/src/main/java/it/uniroma2/pellegrini/z64sim/controller/SimulatorController.java
@@ -356,7 +356,7 @@ public class SimulatorController extends Controller {
 
         boolean cf = src > mask - dst;
         boolean zf = (result & mask) == 0;
-        boolean sf = (result & msbMask) != 0;
+        boolean sf = result < 0;
         boolean of = (src & msbMask) == 0 && (dst & msbMask) == 0 && (result & msbMask) != 0
             || (src & msbMask) != 0 && (dst & msbMask) != 0 && (result & msbMask) == 0;
         boolean pf = countSetBits(result & mask) % 2 == 1;

--- a/src/test/java/it/uniroma2/pellegrini/z64sim/FlagsTest.java
+++ b/src/test/java/it/uniroma2/pellegrini/z64sim/FlagsTest.java
@@ -63,7 +63,7 @@ public class FlagsTest {
     @DisplayName("Overflow Flag")
     public void testOF() {
         SimulatorController.updateFlags(127, 2, 129, 1);
-        Assertions.assertEquals(OF | SF | oneF, SimulatorController.getCpuState().getFlags());
+        Assertions.assertEquals(OF | oneF, SimulatorController.getCpuState().getFlags());
         resetFlags();
         SimulatorController.updateFlags(161, 160, 321, 1);
         Assertions.assertEquals(OF | CF | oneF, SimulatorController.getCpuState().getFlags());
@@ -72,6 +72,6 @@ public class FlagsTest {
         Assertions.assertEquals(oneF, SimulatorController.getCpuState().getFlags());
         resetFlags();
         SimulatorController.updateFlags(135, 253, 388, 1);
-        Assertions.assertEquals(SF | CF | oneF, SimulatorController.getCpuState().getFlags());
+        Assertions.assertEquals(CF | oneF, SimulatorController.getCpuState().getFlags());
     }
 }


### PR DESCRIPTION
PR about issue #6 