### PR TITLE
Fix null dstValue exception when using neg instruction

### DIFF
--- a/src/main/java/it/uniroma2/pellegrini/z64sim/isa/instructions/InstructionClass2.java
+++ b/src/main/java/it/uniroma2/pellegrini/z64sim/isa/instructions/InstructionClass2.java
@@ -95,8 +95,9 @@ public class InstructionClass2 extends Instruction {
             case "neg":
                 result = -srcValue;
                 SimulatorController.setOperandValue(this.source, result & mask);
-                SimulatorController.updateFlags(srcValue, dstValue, result, this.source.getSize(), false);
                 SimulatorController.setCF(srcValue != 0);
+                SimulatorController.setZF(result == 0);
+                SimulatorController.setOF(srcValue == -1 * Math.pow(2, this.source.getSize()));
                 SimulatorController.refreshUIFlags();
                 break;
             case "and":


### PR DESCRIPTION
While using the simulator, I found out that it was impossible to use the `neg` instruction because `dstValue` in _src/main/java/it/uniroma2/pellegrini/z64sim/isa/instructions/InstructionClass2.java_ at _line 43_ was `null`.

The problem was at line 98:
```java 
SimulatorController.updateFlags(srcValue, dstValue, result, this.source.getSize(), false);
```

I simply removed that line and I replaced the `neg` switch case with this:

```java
case "neg":
                result = -srcValue;
                SimulatorController.setOperandValue(this.source, result & mask);
                SimulatorController.setCF(srcValue != 0);
                SimulatorController.setZF(result == 0);
                SimulatorController.setOF(srcValue == -1 * Math.pow(2, this.source.getSize()));
                SimulatorController.refreshUIFlags();
                break;
```
I'm not sure on how to set the **Parity Flag** without making the code dirty... (Maybe `countSetBits()` at _src/main/java/it/uniroma2/pellegrini/z64sim/controller/SimulatorController.java_ should be public?)
