### PR TITLE
Support Java 8

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This is a simulator for the z64 CPU, a fictional CPU designed for educational pu
 ## Getting and running the simulator
 
 Official builds are available through [GitHub Releases](https://github.com/alessandropellegrini/z64sim/releases).
-In order to run it, you need to have Java 11 or later installed. To run the simulator, simply execute the following
+In order to run it, you need to have Java 8 or later installed. To run the simulator, simply execute the following
 command:
 
     java -jar z64sim.jar

--- a/pom.xml
+++ b/pom.xml
@@ -11,8 +11,8 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.target>11</maven.compiler.target>
-        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>1.8</maven.compiler.source>
     </properties>
 
     <dependencies>
@@ -61,8 +61,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.1</version>
                 <configuration>
-                    <source>11</source>
-                    <target>11</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
 

--- a/src/main/java/it/uniroma2/pellegrini/z64sim/controller/AppActions.java
+++ b/src/main/java/it/uniroma2/pellegrini/z64sim/controller/AppActions.java
@@ -28,7 +28,7 @@ public final class AppActions {
         {
             putValue(SHORT_DESCRIPTION, PropertyBroker.getMessageFromBundle("gui.assemble.program"));
             putValue(ACCELERATOR_KEY, KeyStroke.getKeyStroke(KeyEvent.VK_B,
-                    java.awt.Toolkit.getDefaultToolkit().getMenuShortcutKeyMaskEx()));
+                    java.awt.Toolkit.getDefaultToolkit().getMenuShortcutKeyMask()));
         }
 
         @Override

--- a/src/main/java/it/uniroma2/pellegrini/z64sim/view/MainWindow.java
+++ b/src/main/java/it/uniroma2/pellegrini/z64sim/view/MainWindow.java
@@ -30,9 +30,12 @@ import java.awt.*;
 import java.awt.event.*;
 import java.io.File;
 import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Objects;
 import java.util.ResourceBundle;
 
@@ -96,7 +99,7 @@ public class MainWindow extends View {
         assembleButton.addActionListener(AppActions.ASSEMBLE);
 
         Toolkit tk = Toolkit.getDefaultToolkit();
-        final int modKeyMask = tk.getMenuShortcutKeyMaskEx();
+        final int modKeyMask = tk.getMenuShortcutKeyMask();
 
 
         editor.getDocument().addDocumentListener(new DocumentListener() {
@@ -220,7 +223,7 @@ public class MainWindow extends View {
         new SwingWorker<Void, Void>() {
             @Override
             protected Void doInBackground() throws Exception {
-                Files.writeString(fileToSave.toPath(), content);
+                Files.write(fileToSave.toPath(), content.getBytes(StandardCharsets.UTF_8));
                 return null;
             }
 
@@ -257,7 +260,7 @@ public class MainWindow extends View {
         new SwingWorker<String, Void>() {
             @Override
             protected String doInBackground() throws Exception {
-                return Files.readString(Path.of(filePath));
+                return new String(Files.readAllBytes(Paths.get(filePath)), StandardCharsets.UTF_8);
             }
 
             @Override
@@ -336,14 +339,33 @@ public class MainWindow extends View {
         // Set the minimized icon for the jar (works out of the box on Windows and Linux)
         this.mainFrame.setIconImage(image);
 
-        // Now the macOS shit to set the icon in the docker. This is the only place that requires us to
-        // run on Java >8, otherwise it'd be ugly and nasty to check if com.apple.eawt.Application is accessible.
+        // Set the icon in the macOS dock. We use reflection to avoid a compile-time dependency on
+        // java.awt.Taskbar (introduced in Java 9), so the project can target Java 8.
         try {
-            final Taskbar taskbar = Taskbar.getTaskbar();
-            taskbar.setIconImage(image);
-        } catch (final UnsupportedOperationException ignored) {
-        } catch (final SecurityException e) {
-            log.error(PropertyBroker.getMessageFromBundle("exception.security.while.setting.icon"));
+            final Class<?> taskbarClass = Class.forName("java.awt.Taskbar");
+            final Method getTaskbar = taskbarClass.getMethod("getTaskbar");
+            final Object taskbar = getTaskbar.invoke(null);
+            final Method setIconImage = taskbarClass.getMethod("setIconImage", Image.class);
+            setIconImage.invoke(taskbar, image);
+        } catch (final ClassNotFoundException ignored) {
+            // java.awt.Taskbar is not available (Java 8) -- try the legacy Apple API
+            try {
+                final Class<?> appClass = Class.forName("com.apple.eawt.Application");
+                final Method getApp = appClass.getMethod("getApplication");
+                final Object app = getApp.invoke(null);
+                final Method setDockIcon = appClass.getMethod("setDockIconImage", Image.class);
+                setDockIcon.invoke(app, image);
+            } catch (final ReflectiveOperationException alsoIgnored) {
+                // Not on macOS, or the Apple API is not available -- nothing to do
+            }
+        } catch (final InvocationTargetException e) {
+            if (e.getCause() instanceof UnsupportedOperationException) {
+                // Taskbar feature not supported on this platform -- nothing to do
+            } else if (e.getCause() instanceof SecurityException) {
+                log.error(PropertyBroker.getMessageFromBundle("exception.security.while.setting.icon"));
+            }
+        } catch (final ReflectiveOperationException ignored) {
+            // NoSuchMethodException, IllegalAccessException -- should not happen, but fail silently
         }
     }
 

--- a/src/test/java/it/uniroma2/pellegrini/z64sim/ControlFlowTest.java
+++ b/src/test/java/it/uniroma2/pellegrini/z64sim/ControlFlowTest.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.Test;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 
@@ -84,7 +85,7 @@ public class ControlFlowTest {
         //   case1:   mov, jmp
         //   leave:   jz (not taken), add, sub, jmp
         //   end:     hlt
-        List<String> expectedTrace = List.of(
+        List<String> expectedTrace = Arrays.asList(
                 "mov",  // movl var, %eax
                 "mov",  // movq table(,%rax,8), %rax
                 "jmp",  // jmp *%rax  → .case1

--- a/src/test/java/it/uniroma2/pellegrini/z64sim/GuiButtonTest.java
+++ b/src/test/java/it/uniroma2/pellegrini/z64sim/GuiButtonTest.java
@@ -16,8 +16,10 @@ import org.junit.jupiter.api.condition.DisabledIf;
 import javax.swing.*;
 import java.awt.*;
 import java.lang.reflect.Field;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.List;
 
@@ -183,8 +185,9 @@ public class GuiButtonTest {
     @Timeout(15)
     void testStopHaltsExecution() throws Exception {
         // Read the infinite loop program from test resources
-        String program = Files.readString(
-                Path.of(getClass().getClassLoader().getResource("infinite_loop.asm").toURI()));
+        String program = new String(Files.readAllBytes(
+                Paths.get(getClass().getClassLoader().getResource("infinite_loop.asm").toURI())),
+                StandardCharsets.UTF_8);
 
         // Set editor text and click assemble
         SwingUtilities.invokeAndWait(() -> {


### PR DESCRIPTION
I have seen too many students with default Java 8 installations unable to launch the simulator or upgrade. Although Java 8 is ~15 years old, its EOL has been extended to 2030.
Since we needed Java 11 only for whistle and bells, mainly for macOS support, and since it's possible to have all of them also with Java 8, this commit uglifies part of the code base but makes the simulator also run on Java 8.