### PR TITLE
Persistent window size

### DIFF
--- a/src/main/java/it/uniroma2/pellegrini/z64sim/view/MainWindow.java
+++ b/src/main/java/it/uniroma2/pellegrini/z64sim/view/MainWindow.java
@@ -74,7 +74,6 @@ public class MainWindow extends View {
         this.mainFrame.setDefaultCloseOperation(JFrame.DO_NOTHING_ON_CLOSE);
         this.mainFrame.setJMenuBar(new MainWindowMenu());
         this.mainFrame.setMinimumSize(new Dimension(Integer.parseInt(PropertyBroker.getPropertyValue("z64sim.ui.minSizeX")), Integer.parseInt(PropertyBroker.getPropertyValue("z64sim.ui.minSizeY"))));
-        this.mainFrame.setSize(SettingsController.getWindowSize());
         this.mainFrame.addComponentListener(new ComponentAdapter() {
             public void componentResized(ComponentEvent evt) {
                 Component c = (Component) evt.getSource();
@@ -90,6 +89,8 @@ public class MainWindow extends View {
 
         this.setApplicationIcon();
         this.mainFrame.pack();
+        // Apply saved window size after pack(), so it is not overridden
+        this.mainFrame.setSize(SettingsController.getWindowSize());
         newButton.addActionListener(actionEvent -> this.newFile());
         openButton.addActionListener(actionEvent -> this.openFile());
         saveButton.addActionListener(actionEvent -> this.saveFile());


### PR DESCRIPTION
When the main window is resized, the new size is stored in settings. Upon startup, this size was used before pack(), which was overriding the stored dimension. This is now fixed.