### PR TITLE
Fix sign-extension bug in 32-bit arithmetic mask (InstructionClass2)

### DIFF
--- a/src/main/java/it/uniroma2/pellegrini/z64sim/isa/instructions/InstructionClass2.java
+++ b/src/main/java/it/uniroma2/pellegrini/z64sim/isa/instructions/InstructionClass2.java
@@ -51,25 +51,27 @@ public class InstructionClass2 extends Instruction {
         Long srcValue = SimulatorController.getOperandValue(this.source);
         Long dstValue = this.destination != null ? SimulatorController.getOperandValue(this.destination) : 0L;
 
-        long mask = 0;
+        Long mask = 0L;
         switch(this.source.getSize()) {
             case 1:
-                mask = 0xFF;
+                mask = 0xFFL;
                 break;
             case 2:
-                mask = 0xFFFF;
+                mask = 0xFFFFL;
                 break;
             case 4:
-                mask = 0xFFFFFFFF;
+                mask = 0xFFFFFFFFL;
                 break;
             case 8:
                 mask = 0xFFFFFFFFFFFFFFFFL;
                 break;
         }
 
+        Long result = 0L;
+
         switch(mnemonic) {
             case "add":
-                long result = srcValue + dstValue;
+                result = srcValue + dstValue;
                 SimulatorController.setOperandValue(this.destination, result & mask);
                 SimulatorController.updateFlags(srcValue, dstValue, result, this.source.getSize(), false);
                 break;


### PR DESCRIPTION
This fix was previously presented in #19, but the PR was dirty as it also included GUI tweaks that cannot be merged.
So this PR is essentially a cherry pick of a89fcb3 that included the actual fix.

A sign extension in a constant mask caused all 32-bit arithmetic operations (addl, subl, adcl, sbbl, etc.) to produce unmasked 64-bit results rather than being properly truncated to 32 bits.