### PR TITLE
Fix hlt behaviour

### DIFF
--- a/src/main/java/it/uniroma2/pellegrini/z64sim/controller/SimulatorController.java
+++ b/src/main/java/it/uniroma2/pellegrini/z64sim/controller/SimulatorController.java
@@ -461,9 +461,8 @@ public class SimulatorController extends Controller {
 
         if (instruction.getMnemonic().equals("hlt")) {
             halted = true;
-            // Don't advance RIP past hlt — displaceRIP(-size) already done
-            // in InstructionClass0, so RIP stays at hlt.
-            // Check immediately for pending interrupts.
+            // RIP already points past hlt — the halted flag prevents
+            // re-fetching. Check immediately for pending interrupts.
             if (cpuState.getIF() && Devices.getInstance().isIRQPending()) {
                 halted = false;
                 handleInterrupt();

--- a/src/main/java/it/uniroma2/pellegrini/z64sim/isa/instructions/InstructionClass0.java
+++ b/src/main/java/it/uniroma2/pellegrini/z64sim/isa/instructions/InstructionClass0.java
@@ -38,7 +38,9 @@ public class InstructionClass0 extends Instruction {
     @Override
     public void run() {
         if(this.mnemonic.equals("hlt")) {
-            SimulatorController.displaceRIP(-this.size);
+            // Nothing to do — SimulatorController sets the halted flag and
+            // RIP is left pointing past hlt so that interrupt return addresses
+            // are correct.
         }
         if(this.mnemonic.equals("int")) {
             throw new UnsupportedOperationException("Interrupt management is not yet supported.");

--- a/src/main/java/it/uniroma2/pellegrini/z64sim/model/Device.java
+++ b/src/main/java/it/uniroma2/pellegrini/z64sim/model/Device.java
@@ -177,9 +177,13 @@ public abstract class Device {
             action.run();
             return;
         }
-        javax.swing.Timer timer = new javax.swing.Timer(delayMs, e -> action.run());
-        timer.setRepeats(false);
-        timer.start();
+        java.util.Timer timer = new java.util.Timer(true); // daemon thread
+        timer.schedule(new java.util.TimerTask() {
+            @Override
+            public void run() {
+                action.run();
+            }
+        }, delayMs);
     }
 
     // ---- Simulation lifecycle ----

--- a/src/test/java/it/uniroma2/pellegrini/z64sim/AlarmTest.java
+++ b/src/test/java/it/uniroma2/pellegrini/z64sim/AlarmTest.java
@@ -26,9 +26,9 @@ import org.junit.jupiter.api.Test;
 import java.awt.GraphicsEnvironment;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.LinkedHashSet;
 import java.util.Objects;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -96,33 +96,15 @@ public class AlarmTest {
         }
     }
 
-    /**
-     * Step one instruction. If it is {@code hlt} and IF=1, wait for an
-     * interrupt (the real device fires after 200–1000 ms) then dispatch it.
-     */
-    private String stepAndGetMnemonic() throws SimulatorException, InterruptedException {
+    private String stepAndGetMnemonic() throws SimulatorException {
         long rip = SimulatorController.getCpuState().getRIP();
         MemoryElement element = program.getMemoryElementAt(rip);
         assertNotNull(element, "Expected element at RIP=0x" + Long.toHexString(rip));
         assertInstanceOf(Instruction.class, element);
         Instruction instruction = (Instruction) element;
-
-        // Handle hlt: wait for interrupt if IF=1
-        if (instruction.getMnemonic().equals("hlt")
-                && SimulatorController.getCpuState().getIF()) {
-            if (!waitForInterrupt(3000)) {
-                return "hlt";  // terminal halt — no interrupt arrived
-            }
-            // Wake up: advance past hlt and dispatch the interrupt
-            SimulatorController.getCpuState().setRIP(rip + instruction.getSize());
-            dispatchInterrupt();
-            return "hlt";
-        }
-
         SimulatorController.getCpuState().setRIP(rip + instruction.getSize());
         instruction.run();
 
-        // Check for interrupts after non-hlt instructions
         if (SimulatorController.getCpuState().getIF()
                 && Devices.getInstance().isIRQPending()) {
             dispatchInterrupt();
@@ -131,24 +113,12 @@ public class AlarmTest {
         return instruction.getMnemonic();
     }
 
-    private boolean waitForInterrupt(long timeoutMs) throws InterruptedException {
-        if (Devices.getInstance().isIRQPending()) return true;
-        long deadline = System.currentTimeMillis() + timeoutMs;
-        while (System.currentTimeMillis() < deadline) {
-            if (Devices.getInstance().isIRQPending()) return true;
-            Thread.sleep(10);
-        }
-        return Devices.getInstance().isIRQPending();
-    }
-
     private void dispatchInterrupt() {
         long rsp = SimulatorController.getCpuState().getRSP();
         long savedFlags = SimulatorController.getCpuState().getFlags();
         SimulatorController.getCpuState().setIF(false);
-        // Push RIP first (deeper on stack)
         rsp -= 8;
         writeQword(rsp, SimulatorController.getCpuState().getRIP());
-        // Push FLAGS second (top of stack)
         rsp -= 8;
         writeQword(rsp, savedFlags);
         SimulatorController.getCpuState().setRegisterValue(Register.RSP, rsp);
@@ -177,27 +147,23 @@ public class AlarmTest {
 
     @Test
     @DisplayName("Driver sets alarm on/off based on parity of random input value")
-    public void testAlarmFollowsInputParity() throws SimulatorException, InterruptedException {
-        int maxSteps = 50;
+    public void testAlarmFollowsInputParity() throws SimulatorException {
+        final long deadlineMs = System.currentTimeMillis() + 5_000;
+
         boolean handlerRan = false;
         long capturedInput = 0;
         long capturedAlarm = 0;
-        List<String> trace = new ArrayList<>();
+        Set<String> trace = new LinkedHashSet<>();
 
-        for (int i = 0; i < maxSteps; i++) {
+        while (System.currentTimeMillis() < deadlineMs) {
             long rip = SimulatorController.getCpuState().getRIP();
             String mnemonic = stepAndGetMnemonic();
             trace.add(String.format("0x%x: %s", rip, mnemonic));
 
             if (mnemonic.equals("iret") && !handlerRan) {
                 handlerRan = true;
-                // Capture immediately — before a second interrupt can change state
                 capturedInput = inputMapping.read(0x12);   // DATA_IN
                 capturedAlarm = alarmMapping.read(0x20);    // ALARM
-            }
-
-            // After iret, the next instructions are jmp .stop --> hlt (terminal)
-            if (handlerRan && mnemonic.equals("hlt")) {
                 break;
             }
         }

--- a/src/test/java/it/uniroma2/pellegrini/z64sim/AsyncProdConsTest.java
+++ b/src/test/java/it/uniroma2/pellegrini/z64sim/AsyncProdConsTest.java
@@ -24,9 +24,9 @@ import org.junit.jupiter.api.Test;
 
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.LinkedHashSet;
 import java.util.Objects;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -36,8 +36,9 @@ import static org.junit.jupiter.api.Assertions.*;
  * device implementations. Only port/IVN mappings are set up manually.
  * <p>
  * The program spins in a bottom-half guard until both interrupt handlers
- * have run. Since real devices fire after a 200–1000 ms delay, the test
- * thread steps through the spin loop until each timer fires on the EDT.
+ * have run. The device timers fire on a daemon thread after a 200–1000 ms
+ * delay; the test steps through the spin loop until the {@code done}
+ * memory flag is set.
  */
 @DisplayName("Async producer/consumer — async_prodcons.asm (real devices)")
 public class AsyncProdConsTest {
@@ -89,8 +90,6 @@ public class AsyncProdConsTest {
 
     /**
      * Step one instruction with interrupt handling.
-     * The spin loop in async_prodcons.asm (cmpb/jz) naturally keeps
-     * stepping until an EDT timer fires and an IRQ becomes pending.
      */
     private String stepAndGetMnemonic() throws SimulatorException {
         long rip = SimulatorController.getCpuState().getRIP();
@@ -114,10 +113,8 @@ public class AsyncProdConsTest {
         long rsp = SimulatorController.getCpuState().getRSP();
         long savedFlags = SimulatorController.getCpuState().getFlags();
         SimulatorController.getCpuState().setIF(false);
-        // Push RIP first (deeper on stack)
         rsp -= 8;
         writeQword(rsp, SimulatorController.getCpuState().getRIP());
-        // Push FLAGS second (top of stack)
         rsp -= 8;
         writeQword(rsp, savedFlags);
         SimulatorController.getCpuState().setRegisterValue(Register.RSP, rsp);
@@ -147,45 +144,29 @@ public class AsyncProdConsTest {
     @Test
     @DisplayName("Value flows from AsyncInput to AsyncOutput via interrupt handlers")
     public void testAsyncProdCons() throws SimulatorException {
-        // Memory layout: value(.quad)@0x800, done(.byte)@0x808
         final long VALUE_ADDR = 0x800;
         final long DONE_ADDR  = 0x808;
+        final long deadlineMs = System.currentTimeMillis() + 10_000;
 
-        // The spin loop runs until both device timers fire (up to ~2s total).
-        // Allow enough iterations for the timers to complete.
-        int maxSteps = 5_000_000;
-        boolean reachedHlt = false;
-        long lastTraceRip = -1;
-        List<String> trace = new ArrayList<>();
+        boolean done = false;
+        Set<String> trace = new LinkedHashSet<>();
 
-        for (int i = 0; i < maxSteps; i++) {
+        while (System.currentTimeMillis() < deadlineMs) {
             long rip = SimulatorController.getCpuState().getRIP();
             String mnemonic = stepAndGetMnemonic();
+            trace.add(String.format("0x%x: %s", rip, mnemonic));
 
-            // Only trace unique RIP values to avoid flooding with spin-loop entries
-            if (rip != lastTraceRip) {
-                trace.add(String.format("0x%x: %s", rip, mnemonic));
-                lastTraceRip = rip;
-            }
-
-            if (mnemonic.equals("hlt")) {
-                reachedHlt = true;
+            if ((Memory.getValueAt(DONE_ADDR) & 0xFF) == 1) {
+                done = true;
                 break;
             }
         }
 
-        assertTrue(reachedHlt, "Program should reach hlt. Trace:\n"
+        assertTrue(done, "Both interrupt handlers should complete. Trace:\n"
                 + String.join("\n", trace));
 
-        // Read the value that the real AsyncInput generated
-        long inputValue = inputMapping.read(0x12);  // DATA_IN
-
-        // Verify the value was stored correctly in memory
+        long inputValue = inputMapping.read(0x12);
         assertEquals(inputValue, readQword(VALUE_ADDR),
                 "value should contain the 64-bit input from AsyncInput");
-
-        // Verify done flag
-        assertEquals(1, Memory.getValueAt(DONE_ADDR) & 0xFF,
-                "done should be 1 after output completion");
     }
 }

--- a/src/test/java/it/uniroma2/pellegrini/z64sim/InstructionClass0Test.java
+++ b/src/test/java/it/uniroma2/pellegrini/z64sim/InstructionClass0Test.java
@@ -25,12 +25,12 @@ public class InstructionClass0Test {
     }
 
     @Test
-    @DisplayName("hlt displaces RIP backward by instruction size")
+    @DisplayName("hlt leaves RIP unchanged (halted flag prevents re-fetch)")
     public void testHlt() throws ParseException, SimulatorException {
         SimulatorController.getCpuState().setRIP(0x1000L);
         Instruction inst = new InstructionClass0("hlt", null);
         inst.run();
-        assertEquals(0x1000L - 8, SimulatorController.getCpuState().getRIP());
+        assertEquals(0x1000L, SimulatorController.getCpuState().getRIP());
     }
 
     @Test

--- a/src/test/java/it/uniroma2/pellegrini/z64sim/TimerTest.java
+++ b/src/test/java/it/uniroma2/pellegrini/z64sim/TimerTest.java
@@ -23,9 +23,9 @@ import org.junit.jupiter.api.Test;
 
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.LinkedHashSet;
 import java.util.Objects;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -73,10 +73,6 @@ public class TimerTest {
         devices.registerDevice(1, mapping);
     }
 
-    /**
-     * Step one instruction with interrupt handling.
-     * The bottom-half spin loop keeps stepping until the timer fires.
-     */
     private String stepAndGetMnemonic() throws SimulatorException {
         long rip = SimulatorController.getCpuState().getRIP();
         MemoryElement element = program.getMemoryElementAt(rip);
@@ -86,7 +82,6 @@ public class TimerTest {
         SimulatorController.getCpuState().setRIP(rip + instruction.getSize());
         instruction.run();
 
-        // Check for pending interrupts after each instruction
         if (SimulatorController.getCpuState().getIF()
                 && Devices.getInstance().isIRQPending()) {
             dispatchInterrupt();
@@ -99,10 +94,8 @@ public class TimerTest {
         long rsp = SimulatorController.getCpuState().getRSP();
         long savedFlags = SimulatorController.getCpuState().getFlags();
         SimulatorController.getCpuState().setIF(false);
-        // Push RIP first (deeper on stack)
         rsp -= 8;
         writeQword(rsp, SimulatorController.getCpuState().getRIP());
-        // Push FLAGS second (top of stack)
         rsp -= 8;
         writeQword(rsp, savedFlags);
         SimulatorController.getCpuState().setRegisterValue(Register.RSP, rsp);
@@ -132,42 +125,30 @@ public class TimerTest {
     @Test
     @DisplayName("Timer fires interrupt after programmed delay")
     public void testTimerFiresAfterDelay() throws SimulatorException {
-        // Memory layout: fired(.byte)@0x800
         final long FIRED_ADDR = 0x800;
         final long EXPECTED_DELAY_MS = 200;
+        final long deadlineMs = System.currentTimeMillis() + 10_000;
 
         long startTime = System.currentTimeMillis();
+        boolean fired = false;
+        Set<String> trace = new LinkedHashSet<>();
 
-        int maxSteps = 5_000_000;
-        boolean reachedHlt = false;
-        long lastTraceRip = -1;
-        List<String> trace = new ArrayList<>();
-
-        for (int i = 0; i < maxSteps; i++) {
+        while (System.currentTimeMillis() < deadlineMs) {
             long rip = SimulatorController.getCpuState().getRIP();
             String mnemonic = stepAndGetMnemonic();
+            trace.add(String.format("0x%x: %s", rip, mnemonic));
 
-            if (rip != lastTraceRip) {
-                trace.add(String.format("0x%x: %s", rip, mnemonic));
-                lastTraceRip = rip;
-            }
-
-            if (mnemonic.equals("hlt")) {
-                reachedHlt = true;
+            if ((Memory.getValueAt(FIRED_ADDR) & 0xFF) == 1) {
+                fired = true;
                 break;
             }
         }
 
         long elapsed = System.currentTimeMillis() - startTime;
 
-        assertTrue(reachedHlt, "Program should reach hlt. Trace:\n"
+        assertTrue(fired, "Timer interrupt handler should run. Trace:\n"
                 + String.join("\n", trace));
 
-        // Verify fired flag
-        assertEquals(1, Memory.getValueAt(FIRED_ADDR) & 0xFF,
-                "fired should be 1 after timer interrupt");
-
-        // Verify timing: elapsed should be at least the programmed delay
         assertTrue(elapsed >= EXPECTED_DELAY_MS,
                 "Elapsed time (" + elapsed + " ms) should be >= "
                 + EXPECTED_DELAY_MS + " ms");

--- a/src/test/resources/timer.asm
+++ b/src/test/resources/timer.asm
@@ -7,7 +7,7 @@
 .text
   main:
     sti
-    movl $2000, %eax
+    movl $200, %eax
     outl %eax, $TIMER_DELAY
     outb %al, $TIMER_STATUS
    .wait:

--- a/src/test/resources/timer.asm
+++ b/src/test/resources/timer.asm
@@ -7,7 +7,7 @@
 .text
   main:
     sti
-    movl $200, %eax
+    movl $2000, %eax
     outl %eax, $TIMER_DELAY
     outb %al, $TIMER_STATUS
    .wait:
@@ -20,5 +20,6 @@
     pushq %rax
     movb $1, fired
     outb %al, $TIMER_IRQ
+    outb %al, $TIMER_STATUS
     popq %rax
     iret


### PR DESCRIPTION
When serving an interrupt, a halted program continues execution. The current behaviour is that the processor refetches hlt and halts again: this is due to the previous organization of the simulator, which didn't account for interrupts. This PR fixes the behaviour of the hlt instruction.