### PR TITLE
Introduce device examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,16 @@ hardware-level schematic of the device's I/O interface. You can zoom in/out
 The **IVT** (Interrupt Vector Table) panel in the main window shows only
 interrupt-capable devices at their assigned IVN slots.
 
+### Example programs using devices
+
+In [examples](examples/) you can find several assembly programs using the
+provided devices, for you to play with the simulator.
+
+Remember that the configuration of devices (IVN, I/O ports) must match the
+definitions in the assembly programs, otherwise you will likely read/write
+incorrectly or jump to non-existing drivers (in which case, the simulator
+will likely fire an error).
+
 ## Custom Devices
 
 You can implement your own devices and add them to the simulator. Compile

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -4,27 +4,22 @@ SPDX-PackageSupplier = "Alessandro Pellegrini <a.pellegrini@ing.uniroma2.it>"
 SPDX-PackageDownloadLocation = "https://github.com/alessandropellegrini/z64sim"
 
 [[annotations]]
-path = ["src/main/resources/images/**", "artwork/**"]
+path = ["src/main/resources/images/**", "artwork/**", "examples/**"]
 precedence = "aggregate"
-SPDX-FileCopyrightText = "2015-2023 Alessandro Pellegrini <a.pellegrini@ing.uniroma2.it>"
+SPDX-FileCopyrightText = "2015-2026 Alessandro Pellegrini <a.pellegrini@ing.uniroma2.it>"
 SPDX-License-Identifier = "CC-BY-SA-4.0"
 
 [[annotations]]
 path = ["AUTHORS", "CODEOWNERS", "README.md", "src/main/resources/**", "src/test/resources/**", "docs/**", "CHANGELOG.md", "docs/**", ".github/ISSUE_TEMPLATE/**"]
 precedence = "aggregate"
-SPDX-FileCopyrightText = "2015-2023 Alessandro Pellegrini <a.pellegrini@ing.uniroma2.it>"
+SPDX-FileCopyrightText = "2015-2026 Alessandro Pellegrini <a.pellegrini@ing.uniroma2.it>"
 SPDX-License-Identifier = "CC0-1.0"
 
 [[annotations]]
 path = ["pom.xml", "src/main/java/it/uniroma2/pellegrini/z64sim/view/**.form"]
 precedence = "aggregate"
-SPDX-FileCopyrightText = "2015-2023 Alessandro Pellegrini <a.pellegrini@ing.uniroma2.it>"
+SPDX-FileCopyrightText = "2015-2026 Alessandro Pellegrini <a.pellegrini@ing.uniroma2.it>"
 SPDX-License-Identifier = "GPL-3.0-only"
 
-[[annotations]]
-path = [".DS_Store", "src/.DS_Store", "src/main/.DS_Store"]
-precedence = "aggregate"
-SPDX-FileCopyrightText = "2015-2023 Alessandro Pellegrini <a.pellegrini@ing.uniroma2.it>"
-SPDX-License-Identifier = "CC0-1.0"
 
 

--- a/examples/alarm.asm
+++ b/examples/alarm.asm
@@ -1,0 +1,22 @@
+.org 0x800
+.data
+  .equ IN_STATUS, 0x30
+  .equ IN_IRQ, 0x31
+  .equ IN_DATA, 0x32
+  .equ ALARM_PORT, 0x20
+.text
+  main:
+    sti
+    outb %al, $IN_STATUS
+   .stop:
+    hlt
+    jmp .stop
+.driver 2
+    pushq %rax
+    inq $IN_DATA, %rax
+    andb $1, %al
+    outb %al, $ALARM_PORT
+    outb %al, $IN_IRQ
+    outb %al, $IN_STATUS
+    popq %rax
+    iret

--- a/examples/async_prodcons.asm
+++ b/examples/async_prodcons.asm
@@ -1,0 +1,37 @@
+.org 0x800
+.data
+  .equ IN_STATUS, 0x30
+  .equ IN_IRQ, 0x31
+  .equ IN_DATA, 0x32
+  .equ OUT_STATUS, 0x40
+  .equ OUT_IRQ, 0x41
+  .equ OUT_DATA, 0x42
+  value: .quad 0
+  done: .byte 0
+.text
+  main:
+    sti
+    outb %al, $IN_STATUS
+   .wait:
+    cmpb $0, done
+    jz .wait
+   .stop:
+    hlt
+    jmp .stop
+
+.driver 2
+    pushq %rax
+    inq $IN_DATA, %rax
+    movq %rax, value
+    outl %eax, $OUT_DATA
+    outb %al, $OUT_STATUS
+    outb %al, $IN_IRQ
+    popq %rax
+    iret
+
+.driver 3
+    pushq %rax
+    movb $1, done
+    outb %al, $OUT_IRQ
+    popq %rax
+    iret

--- a/examples/busywaiting.asm
+++ b/examples/busywaiting.asm
@@ -1,0 +1,22 @@
+.org 0x800
+.data
+  .equ DEV_STATUS, 0x10
+  .equ DEV_REG, 0x11
+  done: .byte 0
+  result: .long 0
+.text
+  main:
+    movw $DEV_STATUS, %dx
+    outb %al, %dx
+   .bw:
+    inb %dx, %al
+    testb %al, %al
+    jnz .out
+    inb $DEV_STATUS, %al
+    btb $0, %al
+    jnc .bw
+   .out:
+    inl $DEV_REG, %eax
+    movl %eax, result
+    movb $1, done
+    hlt

--- a/examples/dmac.asm
+++ b/examples/dmac.asm
@@ -1,0 +1,13 @@
+.org 0x800
+.data
+  .equ DEV_DATA, 0x51
+  buffer: .fill 8, 1, 0
+
+.text
+  main:
+    cld
+    movw $DEV_DATA, %dx
+    movq $buffer, %rdi
+    movq $8, %rcx
+    insb
+    hlt

--- a/examples/keyboard_terminal.asm
+++ b/examples/keyboard_terminal.asm
@@ -1,0 +1,45 @@
+# keyboard_terminal.asm — Echo keyboard input to the terminal.
+#
+# Keyboard (interrupt-driven):
+#   INT_REQ @ 0x20, DATA @ 0x21
+#   IVN = 1 (hardwired at registration)
+#
+# Terminal (busy-waiting):
+#   STATUS @ 0x30, DATA @ 0x31
+#
+# The keyboard ISR reads the pressed character and stores it in
+# a shared variable. The main loop polls that variable and, when
+# a new character appears, sends it to the terminal.
+.org 0x800
+.data
+  .equ KBD_IRQ,     0x20
+  .equ KBD_DATA,    0x21
+  .equ TERM_STATUS, 0x30
+  .equ TERM_DATA,   0x31
+  new_char: .fill 1, 1, 0     # character received from keyboard (0 = none)
+.text
+  main:
+    sti                        # enable interrupts
+  .loop:
+    cmpb $0, new_char          # any new character?
+    jz .loop                   # no — keep polling
+    # A character is available: send it to the terminal
+    movb new_char, %al         # load the character
+    movb $0, new_char          # clear the flag for the next keypress
+    outb %al, $TERM_DATA       # write character to terminal DATA
+    outb %al, $TERM_STATUS     # start the terminal (write STATUS)
+    jmp .loop                  # back to polling
+# Keyboard ISR (IVN 1)
+.driver 1
+    pushq %rax
+    pushq %rdx
+    # Read the ASCII code from the keyboard DATA register
+    movw $KBD_DATA, %dx
+    inb  %dx, %al
+    movb %al, new_char         # store for the main loop
+    # Clear INT_REQ
+    movw $KBD_IRQ, %dx
+    outb %al, %dx
+    popq %rdx
+    popq %rax
+    iret

--- a/examples/scheduler-round-robin.asm
+++ b/examples/scheduler-round-robin.asm
@@ -1,0 +1,212 @@
+# Simple Round-Robin Scheduler for z64sim
+#
+# Three "processes" run in round-robin fashion, preempted by a timer
+# interrupt. The timer driver saves the full CPU context (including
+# the stack pointer) of the current process and restores the context
+# of the next one.
+#
+# Process 1: scans a small array and accumulates the sum in a loop.
+# Process 2: increments a counter up to a limit, then restarts.
+# Process 3: decrements a counter down to zero, then restarts.
+
+.org 0x800
+
+.data
+  # Timer device I/O ports
+  .equ TIMER_DELAY,  0x10
+  .equ TIMER_STATUS, 0x11
+  .equ TIMER_IRQ,    0x12
+
+  # Scheduling constants
+  .equ NUM_PROCS, 3       # total number of processes
+  .equ QUANTUM,   1000    # timer quantum in milliseconds
+
+  # Table of pointers to the three PCBs.
+  # Lets us index by process number without multiplication:
+  #   pcb_table[curr] -> address of current PCB.
+  pcb_table: .quad pcb1, pcb2, pcb3
+
+  # Process context blocks (PCBs).
+  # Layout per process (9 quads = 72 bytes):
+  # Note that we are not saving all GP registers, for simplicity.
+  #   Offset  0: saved RIP
+  #   Offset  8: saved RFLAGS
+  #   Offset 16: saved RAX
+  #   Offset 24: saved RBX
+  #   Offset 32: saved RCX
+  #   Offset 40: saved RDX
+  #   Offset 48: saved RSI
+  #   Offset 56: saved RDI
+  #   Offset 64: saved RSP
+  pcb1: .quad prog1, 0, 0, 0, 0, 0, 0, 0, stack1 + 256
+  pcb2: .quad prog2, 0, 0, 0, 0, 0, 0, 0, stack2 + 256
+  pcb3: .quad prog3, 0, 0, 0, 0, 0, 0, 0, stack3 + 256
+
+  # Index of the currently running process (0..NUM_PROCS-1)
+  curr: .quad 0
+
+  # Per-process stack areas (256 bytes each).
+  # Stacks grow downward, so the initial RSP points to the
+  # end of each area.
+  stack1: .fill 256, 1, 0
+  stack2: .fill 256, 1, 0
+  stack3: .fill 256, 1, 0
+
+  # ------- Data for Process 1 -------
+  array1:    .long 1, 2, 3, 4
+  .equ ARRAY1_LEN, 4
+
+  # ------- Data for Process 2 -------
+  .equ LIMIT2, 1024
+
+  # ------- Data for Process 3 -------
+  .equ LIMIT3, 2048
+
+.text
+
+main:
+    # ---- Configure and start the timer ----
+    sti                            # enable interrupts globally
+    movl  $QUANTUM, %eax
+    outl  %eax, $TIMER_DELAY
+    outb  %al,  $TIMER_STATUS      # start the timer
+
+    # ---- Launch process 0 ----
+    # Switch to its stack and jump to its entry point.
+    movq  pcb1+64, %rsp
+    xorq  %rax, %rax
+    xorq  %rbx, %rbx
+    xorq  %rcx, %rcx
+    xorq  %rdx, %rdx
+    xorq  %rsi, %rsi
+    xorq  %rdi, %rdi
+    jmp   prog1
+
+
+# =========================================================================
+# Process 1 – Scan an array and accumulate the sum; loop forever.
+# Uses: %rax = pointer, %rbx = count, %rcx = accumulator
+# =========================================================================
+prog1:
+    movq  $array1, %rax
+    movl  $ARRAY1_LEN, %ebx
+    xorq  %rcx, %rcx
+  .p1_loop:
+    cmpl  $0, %ebx
+    jz    prog1                    # restart when done
+    addl  (%rax), %ecx
+    addq  $4, %rax                 # next .long element
+    subl  $1, %ebx
+    jmp   .p1_loop
+
+# =========================================================================
+# Process 2 – Increment a counter up to LIMIT2, then restart.
+# Uses: %rcx = counter
+# =========================================================================
+prog2:
+    xorq  %rcx, %rcx
+  .p2_loop:
+    addq  $1, %rcx
+    cmpq  $LIMIT2, %rcx
+    jz    prog2
+    jmp   .p2_loop
+
+# =========================================================================
+# Process 3 – Decrement a counter from LIMIT3 down to 0, then restart.
+# Uses: %rcx = counter
+# =========================================================================
+prog3:
+    movq  $LIMIT3, %rcx
+  .p3_loop:
+    subq  $1, %rcx
+    cmpq  $0, %rcx
+    jnz   .p3_loop
+    jmp   prog3
+
+
+# =========================================================================
+# Timer ISR – Round-Robin context switch
+#
+# On entry the hardware has pushed (from handleInterrupt):
+#     RSP+0 : saved RFLAGS
+#     RSP+8 : saved RIP  (return address)
+#
+# The driver:
+#  1. Saves GP registers + RSP into the current process's PCB.
+#  2. Advances curr to the next process (wrapping around).
+#  3. Restores the next process's context from its PCB.
+#  4. Re-arms the timer and returns via iret.
+# =========================================================================
+.driver 1
+    # ---- Save current process context ----
+    # We need a scratch register (%rax) to address the PCB.
+    pushq %rax
+
+    # Look up PCB pointer: pcb_base = pcb_table[curr * 8]
+    movq  curr, %rax               # %rax = curr index
+    shlq  $3, %rax                 # %rax = curr * 8 (byte offset in table)
+    addq  $pcb_table, %rax         # %rax = &pcb_table[curr]
+    movq  (%rax), %rax             # %rax = PCB base address
+
+    # Save GP registers (except %rax which we'll recover from the stack)
+    movq  %rbx, 24(%rax)
+    movq  %rcx, 32(%rax)
+    movq  %rdx, 40(%rax)
+    movq  %rsi, 48(%rax)
+    movq  %rdi, 56(%rax)
+
+    # Recover original %rax from the stack and save it
+    popq  %rbx                     # original %rax -> %rbx
+    movq  %rbx, 16(%rax)           # pcb.rax
+
+    # Save RIP and RFLAGS from the interrupt frame on the stack.
+    # After our popq, the stack is back to the interrupt frame:
+    #   RSP+0 : RFLAGS
+    #   RSP+8 : RIP
+    movq  (%rsp), %rbx
+    movq  %rbx, 8(%rax)            # pcb.rflags
+    movq  8(%rsp), %rbx
+    movq  %rbx, (%rax)             # pcb.rip
+
+    # Save RSP. The pre-interrupt value is current RSP + 16
+    # (to account for the RFLAGS + RIP pushed by the hardware).
+    movq  %rsp, %rbx
+    addq  $16, %rbx
+    movq  %rbx, 64(%rax)           # pcb.rsp
+
+    # ---- Advance to the next process (round-robin) ----
+    movq  curr, %rbx
+    addq  $1, %rbx
+    cmpq  $NUM_PROCS, %rbx
+    jnz   .no_wrap
+    xorq  %rbx, %rbx
+  .no_wrap:
+    movq  %rbx, curr
+
+    # ---- Restore next process context ----
+    # Look up next PCB pointer.
+    shlq  $3, %rbx                 # %rbx = new_curr * 8
+    addq  $pcb_table, %rbx         # %rbx = &pcb_table[new_curr]
+    movq  (%rbx), %rbx             # %rbx = new PCB base address
+
+    # Switch to the new process's stack.
+    movq  64(%rbx), %rsp
+
+    # Build an interrupt return frame on the new stack.
+    # iret pops: RFLAGS first, then RIP — so push RIP first (deeper).
+    pushq (%rbx)                   # push saved RIP
+    pushq 8(%rbx)                  # push saved RFLAGS
+
+    # Restore GP registers from the new PCB.
+    movq  16(%rbx), %rax           # pcb.rax
+    movq  32(%rbx), %rcx           # pcb.rcx
+    movq  40(%rbx), %rdx           # pcb.rdx
+    movq  48(%rbx), %rsi           # pcb.rsi
+    movq  56(%rbx), %rdi           # pcb.rdi
+    movq  24(%rbx), %rbx           # pcb.rbx (last — clobbers our pointer)
+
+    # ---- Re-arm the timer and return ----
+    outb  %al, $TIMER_IRQ          # acknowledge previous interrupt
+    outb  %al, $TIMER_STATUS       # restart the timer
+
+    iret

--- a/examples/sync_prodcons.asm
+++ b/examples/sync_prodcons.asm
@@ -1,0 +1,25 @@
+.org 0x800
+.data
+  .equ IN_STATUS, 0x10
+  .equ IN_DATA, 0x11
+  .equ OUT_STATUS, 0x20
+  .equ OUT_DATA, 0x21
+  value: .long 0
+  done: .byte 0
+.text
+  main:
+    outb %al, $IN_STATUS
+   .wait_in:
+    inb $IN_STATUS, %al
+    btb $0, %al
+    jnc .wait_in
+    inl $IN_DATA, %eax
+    movl %eax, value
+    outl %eax, $OUT_DATA
+    outb %al, $OUT_STATUS
+   .wait_out:
+    inb $OUT_STATUS, %al
+    testb %al, %al
+    jz .wait_out
+    movb $1, done
+    hlt

--- a/examples/timer.asm
+++ b/examples/timer.asm
@@ -1,0 +1,24 @@
+.org 0x800
+.data
+  .equ TIMER_DELAY, 0x10
+  .equ TIMER_STATUS, 0x11
+  .equ TIMER_IRQ, 0x12
+  fired: .byte 0
+.text
+  main:
+    sti
+    movl $200, %eax
+    outl %eax, $TIMER_DELAY
+    outb %al, $TIMER_STATUS
+   .wait:
+    cmpb $0, fired
+    jz .wait
+   .stop:
+    hlt
+    jmp .stop
+.driver 1
+    pushq %rax
+    movb $1, fired
+    outb %al, $TIMER_IRQ
+    popq %rax
+    iret

--- a/src/main/java/it/uniroma2/pellegrini/z64sim/model/Program.java
+++ b/src/main/java/it/uniroma2/pellegrini/z64sim/model/Program.java
@@ -207,7 +207,19 @@ public class Program {
             if(labelAddress == null) {
                 throw new ProgramException("Label " + this.label + " was not defined in the program");
             }
-            long target = labelAddress.getTarget();
+
+            // Read the existing value at dataOffset (e.g., the constant offset
+            // from an expression like "label + 256").
+            long existing = 0;
+            for(int i = 0; i < 8; i++) {
+                MemoryElement me = program.binary.get(dataOffset + i);
+                if(me != null) {
+                    existing |= ((long)(me.getValue()[0] & 0xFF)) << (i * 8);
+                }
+            }
+
+            // Add the resolved label address to the existing value
+            long target = labelAddress.getTarget() + existing;
             for(int i = 0; i < 8; i++) { // TODO: 8 bytes are common, but relocation should be more flexible
                 byte currByte = (byte)((target >> (i * 8)) & 0xFF);
                 program.binary.put(dataOffset + i, new MemoryData(currByte));

--- a/src/test/java/it/uniroma2/pellegrini/z64sim/AssemblerTest.java
+++ b/src/test/java/it/uniroma2/pellegrini/z64sim/AssemblerTest.java
@@ -44,6 +44,7 @@ public class AssemblerTest {
         assertDoesNotThrow(() -> assemble("/async_prodcons.asm"));
         assertDoesNotThrow(() -> assemble("/alarm.asm"));
         assertDoesNotThrow(() -> assemble("/timer.asm"));
+        assertDoesNotThrow(() -> assemble("/scheduler-round-robin.asm"));
     }
 
 }

--- a/src/test/resources/scheduler-round-robin.asm
+++ b/src/test/resources/scheduler-round-robin.asm
@@ -1,0 +1,212 @@
+# Simple Round-Robin Scheduler for z64sim
+#
+# Three "processes" run in round-robin fashion, preempted by a timer
+# interrupt. The timer driver saves the full CPU context (including
+# the stack pointer) of the current process and restores the context
+# of the next one.
+#
+# Process 1: scans a small array and accumulates the sum in a loop.
+# Process 2: increments a counter up to a limit, then restarts.
+# Process 3: decrements a counter down to zero, then restarts.
+
+.org 0x800
+
+.data
+  # Timer device I/O ports
+  .equ TIMER_DELAY,  0x10
+  .equ TIMER_STATUS, 0x11
+  .equ TIMER_IRQ,    0x12
+
+  # Scheduling constants
+  .equ NUM_PROCS, 3       # total number of processes
+  .equ QUANTUM,   1000    # timer quantum in milliseconds
+
+  # Table of pointers to the three PCBs.
+  # Lets us index by process number without multiplication:
+  #   pcb_table[curr] -> address of current PCB.
+  pcb_table: .quad pcb1, pcb2, pcb3
+
+  # Process context blocks (PCBs).
+  # Layout per process (9 quads = 72 bytes):
+  # Note that we are not saving all GP registers, for simplicity.
+  #   Offset  0: saved RIP
+  #   Offset  8: saved RFLAGS
+  #   Offset 16: saved RAX
+  #   Offset 24: saved RBX
+  #   Offset 32: saved RCX
+  #   Offset 40: saved RDX
+  #   Offset 48: saved RSI
+  #   Offset 56: saved RDI
+  #   Offset 64: saved RSP
+  pcb1: .quad prog1, 0, 0, 0, 0, 0, 0, 0, stack1 + 256
+  pcb2: .quad prog2, 0, 0, 0, 0, 0, 0, 0, stack2 + 256
+  pcb3: .quad prog3, 0, 0, 0, 0, 0, 0, 0, stack3 + 256
+
+  # Index of the currently running process (0..NUM_PROCS-1)
+  curr: .quad 0
+
+  # Per-process stack areas (256 bytes each).
+  # Stacks grow downward, so the initial RSP points to the
+  # end of each area.
+  stack1: .fill 256, 1, 0
+  stack2: .fill 256, 1, 0
+  stack3: .fill 256, 1, 0
+
+  # ------- Data for Process 1 -------
+  array1:    .long 1, 2, 3, 4
+  .equ ARRAY1_LEN, 4
+
+  # ------- Data for Process 2 -------
+  .equ LIMIT2, 1024
+
+  # ------- Data for Process 3 -------
+  .equ LIMIT3, 2048
+
+.text
+
+main:
+    # ---- Configure and start the timer ----
+    sti                            # enable interrupts globally
+    movl  $QUANTUM, %eax
+    outl  %eax, $TIMER_DELAY
+    outb  %al,  $TIMER_STATUS      # start the timer
+
+    # ---- Launch process 0 ----
+    # Switch to its stack and jump to its entry point.
+    movq  pcb1+64, %rsp
+    xorq  %rax, %rax
+    xorq  %rbx, %rbx
+    xorq  %rcx, %rcx
+    xorq  %rdx, %rdx
+    xorq  %rsi, %rsi
+    xorq  %rdi, %rdi
+    jmp   prog1
+
+
+# =========================================================================
+# Process 1 – Scan an array and accumulate the sum; loop forever.
+# Uses: %rax = pointer, %rbx = count, %rcx = accumulator
+# =========================================================================
+prog1:
+    movq  $array1, %rax
+    movl  $ARRAY1_LEN, %ebx
+    xorq  %rcx, %rcx
+  .p1_loop:
+    cmpl  $0, %ebx
+    jz    prog1                    # restart when done
+    addl  (%rax), %ecx
+    addq  $4, %rax                 # next .long element
+    subl  $1, %ebx
+    jmp   .p1_loop
+
+# =========================================================================
+# Process 2 – Increment a counter up to LIMIT2, then restart.
+# Uses: %rcx = counter
+# =========================================================================
+prog2:
+    xorq  %rcx, %rcx
+  .p2_loop:
+    addq  $1, %rcx
+    cmpq  $LIMIT2, %rcx
+    jz    prog2
+    jmp   .p2_loop
+
+# =========================================================================
+# Process 3 – Decrement a counter from LIMIT3 down to 0, then restart.
+# Uses: %rcx = counter
+# =========================================================================
+prog3:
+    movq  $LIMIT3, %rcx
+  .p3_loop:
+    subq  $1, %rcx
+    cmpq  $0, %rcx
+    jnz   .p3_loop
+    jmp   prog3
+
+
+# =========================================================================
+# Timer ISR – Round-Robin context switch
+#
+# On entry the hardware has pushed (from handleInterrupt):
+#     RSP+0 : saved RFLAGS
+#     RSP+8 : saved RIP  (return address)
+#
+# The driver:
+#  1. Saves GP registers + RSP into the current process's PCB.
+#  2. Advances curr to the next process (wrapping around).
+#  3. Restores the next process's context from its PCB.
+#  4. Re-arms the timer and returns via iret.
+# =========================================================================
+.driver 1
+    # ---- Save current process context ----
+    # We need a scratch register (%rax) to address the PCB.
+    pushq %rax
+
+    # Look up PCB pointer: pcb_base = pcb_table[curr * 8]
+    movq  curr, %rax               # %rax = curr index
+    shlq  $3, %rax                 # %rax = curr * 8 (byte offset in table)
+    addq  $pcb_table, %rax         # %rax = &pcb_table[curr]
+    movq  (%rax), %rax             # %rax = PCB base address
+
+    # Save GP registers (except %rax which we'll recover from the stack)
+    movq  %rbx, 24(%rax)
+    movq  %rcx, 32(%rax)
+    movq  %rdx, 40(%rax)
+    movq  %rsi, 48(%rax)
+    movq  %rdi, 56(%rax)
+
+    # Recover original %rax from the stack and save it
+    popq  %rbx                     # original %rax -> %rbx
+    movq  %rbx, 16(%rax)           # pcb.rax
+
+    # Save RIP and RFLAGS from the interrupt frame on the stack.
+    # After our popq, the stack is back to the interrupt frame:
+    #   RSP+0 : RFLAGS
+    #   RSP+8 : RIP
+    movq  (%rsp), %rbx
+    movq  %rbx, 8(%rax)            # pcb.rflags
+    movq  8(%rsp), %rbx
+    movq  %rbx, (%rax)             # pcb.rip
+
+    # Save RSP. The pre-interrupt value is current RSP + 16
+    # (to account for the RFLAGS + RIP pushed by the hardware).
+    movq  %rsp, %rbx
+    addq  $16, %rbx
+    movq  %rbx, 64(%rax)           # pcb.rsp
+
+    # ---- Advance to the next process (round-robin) ----
+    movq  curr, %rbx
+    addq  $1, %rbx
+    cmpq  $NUM_PROCS, %rbx
+    jnz   .no_wrap
+    xorq  %rbx, %rbx
+  .no_wrap:
+    movq  %rbx, curr
+
+    # ---- Restore next process context ----
+    # Look up next PCB pointer.
+    shlq  $3, %rbx                 # %rbx = new_curr * 8
+    addq  $pcb_table, %rbx         # %rbx = &pcb_table[new_curr]
+    movq  (%rbx), %rbx             # %rbx = new PCB base address
+
+    # Switch to the new process's stack.
+    movq  64(%rbx), %rsp
+
+    # Build an interrupt return frame on the new stack.
+    # iret pops: RFLAGS first, then RIP — so push RIP first (deeper).
+    pushq (%rbx)                   # push saved RIP
+    pushq 8(%rbx)                  # push saved RFLAGS
+
+    # Restore GP registers from the new PCB.
+    movq  16(%rbx), %rax           # pcb.rax
+    movq  32(%rbx), %rcx           # pcb.rcx
+    movq  40(%rbx), %rdx           # pcb.rdx
+    movq  48(%rbx), %rsi           # pcb.rsi
+    movq  56(%rbx), %rdi           # pcb.rdi
+    movq  24(%rbx), %rbx           # pcb.rbx (last — clobbers our pointer)
+
+    # ---- Re-arm the timer and return ----
+    outb  %al, $TIMER_IRQ          # acknowledge previous interrupt
+    outb  %al, $TIMER_STATUS       # restart the timer
+
+    iret


### PR DESCRIPTION
With this commit, several examples using devices are introduced.

Resurrecting the scheduler example allowed me to spot a bug in the way relocations were resolved. This is fixed.